### PR TITLE
Fix: resolve check-bioc.yml failures

### DIFF
--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -53,9 +53,9 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { os: ubuntu-latest, r: 'devel', bioc: '3.21', cont: "bioconductor/bioconductor_docker:devel", rspm: "https://packagemanager.rstudio.com/cran/__linux__/jammy/latest" }
-          - { os: macOS-latest, r: 'devel', bioc: '3.21'}
-          - { os: windows-latest, r: 'devel', bioc: '3.21'}
+          - { os: ubuntu-latest, r: 'devel', bioc: '3.23', cont: "bioconductor/bioconductor_docker:devel", rspm: "https://packagemanager.rstudio.com/cran/__linux__/jammy/latest" }
+          - { os: macOS-latest, r: 'devel', bioc: '3.23'}
+          - { os: windows-latest, r: 'devel', bioc: '3.23'}
           ## Check https://github.com/r-lib/actions/tree/master/examples
           ## for examples using the http-user-agent
     env:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,13 +33,14 @@ Suggests:
     BiocStyle,
     countrycode,
     knitr,
+    pak,
     rmarkdown,
     testthat (>= 3.0.0)
 biocViews: Software, DataImport, BiomedicalInformatics, Pharmacogenomics, Pharmacogenomics
 Encoding: UTF-8
 ByteCompile: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Config/testthat/edition: 3
 Config/testthat/parallel: true
 VignetteBuilder: knitr

--- a/R/import-standalone-pkg.R
+++ b/R/import-standalone-pkg.R
@@ -70,13 +70,13 @@ is_installed <- local({
     }
 })
 
-install_pkgs <- function(pkgs) {
-    if (is_installed("pak")) {
-        getExportedValue("pak", "pkg_install")(pkgs, ask = FALSE)
-    } else {
-        utils::install.packages(pkgs)
-    }
-}
+# install_pkgs <- function(pkgs) {
+#     if (is_installed("pak")) {
+#         getExportedValue("pak", "pkg_install")(pkgs, ask = FALSE)
+#     } else {
+#         utils::install.packages(pkgs)
+#     }
+# }
 
 pkg_nm <- function() utils::packageName(environment())
 


### PR DESCRIPTION
- Bioconductor packages are not allowed to include any built-in package installation functionality.  
  Removed the `install_pkgs` function to resolve compliance issues. Users must install required packages manually via `install.packages()` or `BiocManager::install()`.

- Upgraded Bioconductor version to 3.23.